### PR TITLE
#41 Do not call clearData()

### DIFF
--- a/src/useDragging.tsx
+++ b/src/useDragging.tsx
@@ -53,7 +53,6 @@ export default function useDragging({ labelRef, inputRef, multiple, handleChange
         const files = multiple ? _files : _files[0];
         const success = handleChanges(files);
         if (onDrop && success) onDrop(files);
-        ev.dataTransfer.clearData();
       }
     },
     [handleChanges]


### PR DESCRIPTION
Per [the documenation](https://developer.mozilla.org/en-US/docs/Web/API/DataTransfer/clearData), we are only supposed to modify the drag operation's data store during the `dragstart` event. We were calling it in the `drop` event. This was not throwing errors in Chrome, but Firefox, for example would throw a `NoModificationAllowedError`.

Initially, I figured to move the call to `dataTransfer.clearData()` to the `dragstart` event handler. I noticed we did not even have a handler for this method. Then I realized this is because when a user drags a file into our dropzone, we never see the start event of that drag operation.

Therefore, I simply removed the call to `dataTransfer.clearData()`.
