### PR TITLE
Function(onDrop) appears(hover) when trying to drop a file

### DIFF
--- a/src/FileUploader.tsx
+++ b/src/FileUploader.tsx
@@ -29,6 +29,7 @@ type Props = {
   onSelect?: (arg0: File | Array<File>) => void;
   handleChange?: (arg0: File | Array<File> | File) => void;
   onDraggingStateChange?: (dragging: boolean) => void;
+  onDrag?: () => void;
 };
 /**
  *
@@ -119,7 +120,8 @@ const FileUploader: React.FC<Props> = (props: Props): JSX.Element => {
     disabled,
     label,
     multiple,
-    onDraggingStateChange
+    onDraggingStateChange,
+    onDrag
   } = props;
   const labelRef = useRef<HTMLLabelElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -184,6 +186,9 @@ const FileUploader: React.FC<Props> = (props: Props): JSX.Element => {
 
   useEffect(() => {
     onDraggingStateChange?.(dragging);
+    if(dragging){
+      onDrag?.();
+    }
   }, [dragging]);
 
   useEffect(() => {


### PR DESCRIPTION
Function(onDrop) appears(hover) when trying to drop a file

### Summary

Added a function that is called on the hover to allow the user to better control the "hover"


#### Key Changes

- add (optional) property onDrop a function that will be called when trying to drop a file. 


### Check List

- [x] The changes to the "Readme" file(if needed)
- [x] The changes not breaking any old rule of the library or usage