### PR TITLE
fix: Hover state background to be solid

### DIFF
--- a/src/style.ts
+++ b/src/style.ts
@@ -43,12 +43,13 @@ export const HoverMsg = styled.div`
   border: dashed 2px ${darkGray};
   border-radius: 5px;
   background-color: ${lightGray};
-  opacity: 0.5;
+  opacity: 0.9;
   position: absolute;
   top: 0;
   right: 0;
   left: 0;
   bottom: 0;
+  z-index: 999;
   & > span {
     position: absolute;
     top: 50%;


### PR DESCRIPTION
### Summary

In latest Chromium browsers the HoverMsg element is displayed underneath the drag text and the opacity is too low to be readable.

![image](https://user-images.githubusercontent.com/622056/178832825-a117a328-f56b-49b2-b0e5-2b95b0384400.png)
(mouse circle from screen recording software)

#### Key Changes

- Updated Opacity from .5 to .9
- Added z-index on HoverMsg style

#### Updated look

![image](https://user-images.githubusercontent.com/622056/178833730-9bb9faa6-12e3-4157-8cf2-298c18fc88d2.png)
(mouse circle from screen recording software)


### Check List

- [x] The changes to the "Readme" file(if needed)
- [x] The changes not breaking any old rule of the library or usage