### PR TITLE
feat: add required prop & dropzone keyboard focus indicator (#93)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ export default DragDrop;
 | name         | string           | the name for your form (if exist)                                                                                   | `"myFile"`                                                |
 | multiple | boolean         | a boolean to determine whether the multiple files is enabled or not                                                    | `true OR false - false by default`                             |
 | label        | string           | the label (text) for your form (if exist) inside the uploading box - first word underlined                                                                                  | `"Upload or drop a file right here"`                      |
+| required     | boolean          | Conditionally set the input field as required | `true` or `false`|
 | disabled     | boolean          | this for disabled the input                                                                                         | `true OR false`                                           |
 | hoverTitle   | string           | text appears(hover) when trying to drop a file                                                                      | `"Drop here"`                                             |
 | fileOrFiles         | Array<File> or File or null     | this mainly made because if you would like to remove uploaded file(s) pass null or pass another file as initial        |

--- a/src/FileUploader.tsx
+++ b/src/FileUploader.tsx
@@ -23,6 +23,7 @@ type Props = {
   disabled?: boolean | false;
   label?: string | undefined;
   multiple?: boolean | false;
+  required?: boolean | false;
   onSizeError?: (arg0: string) => void;
   onTypeError?: (arg0: string) => void;
   onDrop?: (arg0: File | Array<File>) => void;
@@ -98,6 +99,7 @@ const drawDescription = (
     disabled,
     label,
     multiple,
+    required,
     onDraggingStateChange
   }
  * @returns JSX Element
@@ -120,6 +122,7 @@ const FileUploader: React.FC<Props> = (props: Props): JSX.Element => {
     disabled,
     label,
     multiple,
+    required,
     onDraggingStateChange,
     dropMessageStyle
   } = props;
@@ -229,6 +232,7 @@ const FileUploader: React.FC<Props> = (props: Props): JSX.Element => {
         name={name}
         disabled={disabled}
         multiple={multiple}
+        required={required}
       />
       {dragging && (
         <HoverMsg style={dropMessageStyle}>

--- a/src/style.ts
+++ b/src/style.ts
@@ -31,8 +31,14 @@ export const UploaderWrapper = styled.label<any>`
       }
     }
   }
+  &:focus-within {
+    outline: 2px solid black;
+  }
   & > input {
-    display: none;
+    display: block;
+    opacity: 0;
+    position: absolute;
+    pointer-events: none;
   }
 `;
 /**


### PR DESCRIPTION
### Summary
Improved keyboard support for accessibility. And added basic required support.

I use the `FileUploader` component to push multiple files into an array. If users don't submit any files, I want the form to be invalid.

Example:

`<FileUploader required={filesArray.length === 0} />`

- When no files are submitted into the array, length is 0, mark the field as required and prevent progression (the input field itself has no value).
- When there are files in the array, remove the required attribute allowing progression.


#### Key Changes

- ability to toggle input `required` attribute 
- improves accessibility by allowing the drop-zone to receive keyboard focus and show a visible focus indicator.


### Check List

- [x] The changes to the "Readme" file(if needed)
- [x] The changes not breaking any old rule of the library or usage