### PR TITLE
Fix is-disabled styles overriding custom styles set by children

### DIFF
--- a/src/style.ts
+++ b/src/style.ts
@@ -15,10 +15,7 @@ const defaultStyle = css`
   border-radius: 5px;
   cursor: pointer;
   flex-grow: 0;
-`;
-export const UploaderWrapper = styled.label<any>`
-  position: relative;
-  ${(props) => (props.overRide ? '' : defaultStyle)};
+
   &.is-disabled {
     border: dashed 2px ${darkGray};
     cursor: no-drop;
@@ -31,6 +28,10 @@ export const UploaderWrapper = styled.label<any>`
       }
     }
   }
+`;
+export const UploaderWrapper = styled.label<any>`
+  position: relative;
+  ${(props) => (props.overRide ? '' : defaultStyle)};
   & > input {
     display: none;
   }


### PR DESCRIPTION
### Summary

Fixes is-disabled styles overriding custom styles set by user in children.

Also reported by another user in: https://github.com/KarimMokhtar/react-drag-drop-files/issues/98


#### Key Changes

Fixes broken css styling when input is disabled and user is using children.


### Check List

- [x] The changes to the "Readme" file(if needed)
- [x] The changes not breaking any old rule of the library or usage