### PR TITLE
fix: upload same file multiple times

### DIFF
--- a/src/FileUploader.tsx
+++ b/src/FileUploader.tsx
@@ -213,7 +213,7 @@ const FileUploader: React.FC<Props> = (props: Props): JSX.Element => {
       setUploaded(false);
       setFile(null);
     }
-  }, [fileOrFiles]);
+  }, [fileOrFiles, inputRef]);
 
   return (
     <UploaderWrapper


### PR DESCRIPTION
### Summary
Previously, a user could not upload the same file twice.  Now, a user can upload the same file multiple times.


#### Key Changes

-  Add `inputRef` to the dependency array of the useEffect that handles changing `fileOrFiles`.


### Check List

- [x] The changes to the "Readme" file(if needed)
- [x] The changes not breaking any old rule of the library or usage