### PR TITLE
feat: Pass error label to component

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ export default DragDrop;
 | handleChange | function         | function that will be called when the user selects or drops file(s)                                                    | `(file) => console.log(file)`                             |
 | onDraggingStateChange | function         | function that will be called with the state of dragging                                                    | `(dragging) => console.log(dragging)`                             |
 | dropMessageStyle | CSS Properties         | A CSS property to style the hover message                                                    | `{backgroundColor: 'red'}`                             |
+| errorLabel         | string           | text appears if there is an error                                                                                   | `"File type/size error"`                                                |
 
 ## How to contribute:
   - Please follow the instructions inside this file: [here](CONTRIBUTION.md)

--- a/src/FileUploader.tsx
+++ b/src/FileUploader.tsx
@@ -22,6 +22,7 @@ type Props = {
   fileOrFiles?: Array<File> | File | null;
   disabled?: boolean | false;
   label?: string | undefined;
+  errorLabel?: string | undefined;
   multiple?: boolean | false;
   required?: boolean | false;
   onSizeError?: (arg0: string) => void;
@@ -40,6 +41,7 @@ type Props = {
  * @param typeError - boolean to check if the file has type errors
  * @param disabled - boolean to check if input is disabled
  * @param label - string to add custom label
+ * @param errorLabel - string to add custom error label
  * @returns JSX Element
  *
  * @internal
@@ -50,10 +52,11 @@ const drawDescription = (
   uploaded: boolean,
   typeError: boolean,
   disabled: boolean | undefined,
-  label: string | undefined
+  label: string | undefined,
+  errorLabel: string | undefined
 ) => {
   return typeError ? (
-    <span>File type/size error, Hovered on types!</span>
+    <span>{errorLabel || "File type/size error, Hovered on types!"}</span>
   ) : (
     <Description>
       {disabled ? (
@@ -100,7 +103,8 @@ const drawDescription = (
     label,
     multiple,
     required,
-    onDraggingStateChange
+    onDraggingStateChange,
+    errorLabel
   }
  * @returns JSX Element
  */
@@ -124,7 +128,8 @@ const FileUploader: React.FC<Props> = (props: Props): JSX.Element => {
     multiple,
     required,
     onDraggingStateChange,
-    dropMessageStyle
+    dropMessageStyle,
+    errorLabel
   } = props;
   const labelRef = useRef<HTMLLabelElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -243,7 +248,7 @@ const FileUploader: React.FC<Props> = (props: Props): JSX.Element => {
         <>
           <ImageAdd />
           <DescriptionWrapper error={error}>
-            {drawDescription(currFiles, uploaded, error, disabled, label)}
+            {drawDescription(currFiles, uploaded, error, disabled, label, errorLabel)}
             <DrawTypes types={types} minSize={minSize} maxSize={maxSize} />
           </DescriptionWrapper>
         </>


### PR DESCRIPTION
### Summary

At the moment a hard coded value is being used if there is a type or size error. This PR will add a prop to the library which will allow users to pass in a custom message. 


#### Key Changes

- src/FileUploader.tsx => drawDescription 
- README


### Check List

- [ ] The changes to the "Readme" file(if needed)
- [ ] The changes not breaking any old rule of the library or usage