### PR TITLE
Fix: #99 -- Allow user to select the same file

### DIFF
--- a/src/FileUploader.tsx
+++ b/src/FileUploader.tsx
@@ -182,6 +182,7 @@ const FileUploader: React.FC<Props> = (props: Props): JSX.Element => {
     ev.stopPropagation();
     // eslint-disable-next-line no-param-reassign
     if (inputRef && inputRef.current) {
+      inputRef.current.value = null;
       inputRef.current.click();
     }
   };

--- a/src/FileUploader.tsx
+++ b/src/FileUploader.tsx
@@ -182,7 +182,7 @@ const FileUploader: React.FC<Props> = (props: Props): JSX.Element => {
     ev.stopPropagation();
     // eslint-disable-next-line no-param-reassign
     if (inputRef && inputRef.current) {
-      inputRef.current.value = null;
+      inputRef.current.value = '';
       inputRef.current.click();
     }
   };


### PR DESCRIPTION
### Summary

Fix: Reset value of the input to allow the user to select the same file again.
Fixes https://github.com/KarimMokhtar/react-drag-drop-files/issues/99
Overrides: https://github.com/KarimMokhtar/react-drag-drop-files/pull/107

#### Key Changes

- Added `inputRef.current.value = ''` which resets the value of the input allowing the user to select the same file that was previously selected.

### Check List

- [x] The changes to the "Readme" file(if needed)
- [x] The changes not breaking any old rule of the library or usage