### PR TITLE
refactor: changed return type for handleChanges in useDragging Params

### DIFF
--- a/src/useDragging.tsx
+++ b/src/useDragging.tsx
@@ -5,7 +5,7 @@ type Params = {
   labelRef: any;
   inputRef: any;
   multiple?: boolean | false;
-  handleChanges: (arg0: Array<File>) => void;
+  handleChanges: (arg0: Array<File>) => boolean;
   onDrop?: (arg0: Array<File>) => void;
 };
 


### PR DESCRIPTION
### Summary

Declared function handleChanges in `FileUploader.tsx` returns boolean, but in `useDragging.tsx` Params it's defined as void. Later its return value is checked, but this part of code in `useDragging.tsx`
```ts
        const success = handleChanges(files);
        if (onDrop && success) onDrop(files);
```
generates a warning `"An expression of type 'void' cannot be tested for truthiness"`


#### Key Changes

- Params typing in useDragging.tsx


### Check List

- [ ] The changes to the "Readme" file(if needed)
- [x] The changes not breaking any old rule of the library or usage