### PR TITLE
feat: Add in typeErrorLabel for custom message on fileTypeError.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ export default DragDrop;
 | name         | string           | the name for your form (if exist)                                                                                   | `"myFile"`                                                |
 | multiple | boolean         | a boolean to determine whether the multiple files is enabled or not                                                    | `true OR false - false by default`                             |
 | label        | string           | the label (text) for your form (if exist) inside the uploading box - first word underlined                                                                                  | `"Upload or drop a file right here"`                      |
+| typeErrorLabel        | string           | the label (text) for the error message if a file doesn't meet the fileType requirements                        | `"That file type is not accepted"`    |
 | required     | boolean          | Conditionally set the input field as required | `true` or `false`|
 | disabled     | boolean          | this for disabled the input                                                                                         | `true OR false`                                           |
 | hoverTitle   | string           | text appears(hover) when trying to drop a file                                                                      | `"Drop here"`                                             |

--- a/src/FileUploader.tsx
+++ b/src/FileUploader.tsx
@@ -51,7 +51,7 @@ const drawDescription = (
   currFile: Array<File> | File | null,
   uploaded: boolean,
   typeError: boolean,
-  typeErrorLabel?: string
+  typeErrorLabel?: string,
   disabled: boolean | undefined,
   label: string | undefined
 ) => {

--- a/src/FileUploader.tsx
+++ b/src/FileUploader.tsx
@@ -22,6 +22,7 @@ type Props = {
   fileOrFiles?: Array<File> | File | null;
   disabled?: boolean | false;
   label?: string | undefined;
+  typeErrorLabel?: string | undefined;
   multiple?: boolean | false;
   required?: boolean | false;
   onSizeError?: (arg0: string) => void;
@@ -38,6 +39,7 @@ type Props = {
  * @param currFile - The uploaded file
  * @param uploaded - boolean to check if the file uploaded or not yet
  * @param typeError - boolean to check if the file has type errors
+ * @param typeErrorLabel - string to add custom type error label
  * @param disabled - boolean to check if input is disabled
  * @param label - string to add custom label
  * @returns JSX Element
@@ -49,11 +51,12 @@ const drawDescription = (
   currFile: Array<File> | File | null,
   uploaded: boolean,
   typeError: boolean,
+  typeErrorLabel?: string
   disabled: boolean | undefined,
   label: string | undefined
 ) => {
   return typeError ? (
-    <span>File type/size error, Hovered on types!</span>
+    <span>{typeErrorLabel || 'File type/size error'}</span>
   ) : (
     <Description>
       {disabled ? (
@@ -98,6 +101,7 @@ const drawDescription = (
     onTypeError,
     disabled,
     label,
+    typeErrorLabel,
     multiple,
     required,
     onDraggingStateChange
@@ -121,6 +125,7 @@ const FileUploader: React.FC<Props> = (props: Props): JSX.Element => {
     onDrop,
     disabled,
     label,
+    typeErrorLabel,
     multiple,
     required,
     onDraggingStateChange,
@@ -244,7 +249,7 @@ const FileUploader: React.FC<Props> = (props: Props): JSX.Element => {
         <>
           <ImageAdd />
           <DescriptionWrapper error={error}>
-            {drawDescription(currFiles, uploaded, error, disabled, label)}
+            {drawDescription(currFiles, uploaded, error, disabled, label, typeErrorLabel)}
             <DrawTypes types={types} minSize={minSize} maxSize={maxSize} />
           </DescriptionWrapper>
         </>


### PR DESCRIPTION
### Summary

Add a type error label. If the user drops a file in that doesn't meet the fileTypes, show a custom error message. 


#### Key Changes

- typeErrorLabel
- README.md


### Check List

- [x] The changes to the "Readme" file(if needed)
- [x] The changes not breaking any old rule of the library or usage
