### PR TITLE
Add an id attribute to the file input element

### DIFF
--- a/src/FileUploader.tsx
+++ b/src/FileUploader.tsx
@@ -230,6 +230,7 @@ const FileUploader: React.FC<Props> = (props: Props): JSX.Element => {
         accept={acceptedExt(types)}
         ref={inputRef}
         type="file"
+        id={name}
         name={name}
         disabled={disabled}
         multiple={multiple}


### PR DESCRIPTION
### Summary
This Pull Request addresses the following issue:

Fix of the browser error: 
"Incorrect use of `<label for=FORM_ELEMENT>`: The label's "for" attribute didn't match any element ID, which could prevent the browser from autofilling the form and affect accessibility tools".




#### Key Changes

An "id" attribute has been added to the file input element in the FileUploader component to resolve the issue.


### Check List

- [ ] The changes to the "Readme" file(if needed)
- [x] The changes not breaking any old rule of the library or usage