### PR TITLE
fix: upgrade styled-components to fix snyk vulnerable issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   },
   "dependencies": {
     "prop-types": "^15.7.2",
-    "styled-components": "^5.3.0"
+    "styled-components": "^6.1.11"
   },
   "peerDependencies": {
     "react": "^18.0.0",


### PR DESCRIPTION
### Summary

[What does this PR introduce?]
Upgraded styled-components package to fix snyk vulnerable issue.

Vulnerable module : @babel/traverse
Introduced through : client_configurator@0.0.1 > react-drag-drop-files@2.3.10 > styled-components@5.3.11 > @babel/traverse@7.15.0
Fixed in : @babel/traverse@7.23.2, 8.0.0-alpha.4 (latest babel/traverse version)

#### Key Changes
- [List the changes to look for in this PR]
Upgraded styled-components package from 5.3.x to 6.1.11

### Check List

- [x] The changes to the "Readme" file(if needed)
- [x] The changes not breaking any old rule of the library or usage