### PR TITLE
fix: Remove overRide attribute from UploadWrapper styles compoennt

### DIFF
--- a/src/FileUploader.tsx
+++ b/src/FileUploader.tsx
@@ -234,7 +234,7 @@ const FileUploader: React.FC<Props> = (props: Props): JSX.Element => {
 
   return (
     <UploaderWrapper
-      overRide={children}
+      $overRide={children}
       className={`${classes || ''} ${disabled ? 'is-disabled' : ''}`}
       ref={labelRef}
       htmlFor={name}

--- a/src/style.ts
+++ b/src/style.ts
@@ -29,9 +29,7 @@ const defaultStyle = css`
     }
   }
 `;
-export const UploaderWrapper =  styled.label.attrs<any>((props) => ({
-  overRide: undefined,
-}))<any>`
+export const UploaderWrapper =  styled.label<any>`
   position: relative;
   ${(props) => (props.overRide ? '' : defaultStyle)};
   &:focus-within {

--- a/src/style.ts
+++ b/src/style.ts
@@ -29,7 +29,9 @@ const defaultStyle = css`
     }
   }
 `;
-export const UploaderWrapper = styled.label<any>`
+export const UploaderWrapper =  styled.label.attrs<any>((props) => ({
+  overRide: undefined,
+}))<any>`
   position: relative;
   ${(props) => (props.overRide ? '' : defaultStyle)};
   &:focus-within {

--- a/src/style.ts
+++ b/src/style.ts
@@ -31,7 +31,7 @@ const defaultStyle = css`
 `;
 export const UploaderWrapper =  styled.label<any>`
   position: relative;
-  ${(props) => (props.overRide ? '' : defaultStyle)};
+  ${(props) => (props.$overRide ? '' : defaultStyle)};
   &:focus-within {
     outline: 2px solid black;
   }


### PR DESCRIPTION
This PR ensures that the overRide prop is filtered out and no longer forwarded to the DOM in the UploaderWrapper styled-component. This keeps the rendered HTML clean and avoids invalid attribute warnings
![image](https://github.com/user-attachments/assets/3ef26d38-f688-42ec-b79f-08a14cdcb962)
