### PR TITLE
refactor: rename overRide to override

### DIFF
--- a/src/FileUploader.tsx
+++ b/src/FileUploader.tsx
@@ -234,7 +234,7 @@ const FileUploader: React.FC<Props> = (props: Props): JSX.Element => {
 
   return (
     <UploaderWrapper
-      overRide={children}
+      override={children}
       className={`${classes || ''} ${disabled ? 'is-disabled' : ''}`}
       ref={labelRef}
       htmlFor={name}

--- a/src/style.ts
+++ b/src/style.ts
@@ -31,7 +31,7 @@ const defaultStyle = css`
 `;
 export const UploaderWrapper = styled.label<any>`
   position: relative;
-  ${(props) => (props.overRide ? '' : defaultStyle)};
+  ${(props) => (props.override ? '' : defaultStyle)};
   &:focus-within {
     outline: 2px solid black;
   }


### PR DESCRIPTION
### Summary

Resolve ``React does not recognize the `overRide` prop on a DOM element`` error when running jest tests that test a component using this package.

#### Key Changes

- Just a simple rename of `overRide` to `override`

### Check List

- [ ] The changes to the "Readme" file(if needed)
- [x] The changes not breaking any old rule of the library or usage